### PR TITLE
refactor: avoid JSON.stringify in useEffect hook dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "kalend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kalend",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "color": "4.2.3",
+        "dequal": "^2.0.3",
         "kalend-layout": "0.0.17",
         "luxon": "2.5.0"
       },
@@ -7779,6 +7780,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/des.js": {
@@ -33076,6 +33085,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "des.js": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "color": "4.2.3",
+    "dequal": "^2.0.3",
     "kalend-layout": "0.0.17",
     "luxon": "2.5.0"
   },
@@ -42,9 +43,9 @@
     "eslint": "8.20.0",
     "eslint-config-prettier": "7.2.0",
     "eslint-config-react": "1.1.7",
+    "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-sort-imports-es6-autofix": "0.6.0",
     "eslint-plugin-unused-imports": "2.0.0",
-    "eslint-plugin-prettier": "4.2.1",
     "faker": "5.5.3",
     "gulp": "4.0.2",
     "gulp-concat": "2.6.1",

--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 import { getCalendarDays, getRange } from './utils/calendarDays';
 import { isSameMonth, parseCssDark } from './utils/common';
 import { useContext, useEffect, useLayoutEffect, useState } from 'react';
+import { useDeepCompareLayoutEffect } from './utils/useDeepCompareEffect';
 import AgendaView from './components/agendaView/AgendaView';
 import CalendarDesktopNavigation from './components/CalendarDesktopNavigation/CalendarDesktopNavigation';
 import CalendarHeader from './components/calendarHeader/CalendarHeader';
@@ -109,9 +110,9 @@ const Calendar = (props: CalendarProps) => {
     }
   }, [selectedView]);
 
-  useLayoutEffect(() => {
+  useDeepCompareLayoutEffect(() => {
     setContext('events', props.events);
-  }, [JSON.stringify(props.events)]);
+  }, [props.events]);
 
   useLayoutEffect(() => {
     if (

--- a/src/components/agendaView/AgendaView.tsx
+++ b/src/components/agendaView/AgendaView.tsx
@@ -4,6 +4,7 @@ import { Context } from '../../context/store';
 import { DateTime } from 'luxon';
 import { getSelectedViewType } from '../../utils/common';
 import { useContext, useEffect, useState } from 'react';
+import { useDeepCompareEffect } from '../../utils/useDeepCompareEffect';
 import AgendaDayRow from './agendaDayRow/AgendaDayRow';
 import KalendLayout from 'kalend-layout';
 import LuxonHelper, { EVENTS_DAY_FORMAT } from '../../utils/luxonHelper';
@@ -63,7 +64,7 @@ const AgendaView = (props: AgendaViewProps) => {
     }
   }, [calendarDays[0]]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     // don't need to call this immediately
     if (wasInit) {
       if (!hasExternalLayout) {
@@ -82,9 +83,9 @@ const AgendaView = (props: AgendaViewProps) => {
         });
       }
     }
-  }, [JSON.stringify(events)]);
+  }, [events]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (
       hasExternalLayout &&
       getSelectedViewType(props.eventLayouts.selectedView) ===
@@ -98,7 +99,7 @@ const AgendaView = (props: AgendaViewProps) => {
       );
       setCalendarContent(content);
     }
-  }, [JSON.stringify(props.eventLayouts)]);
+  }, [props.eventLayouts]);
 
   return (
     <div className={'Kalend__Agenda__container'} style={{ height: '100%' }}>

--- a/src/components/calendarHeader/calendarHeaderEvents/CalendarHeaderEvents.tsx
+++ b/src/components/calendarHeader/calendarHeaderEvents/CalendarHeaderEvents.tsx
@@ -2,7 +2,8 @@ import { Context } from '../../../context/store';
 import { DateTime } from 'luxon';
 import { EVENT_TYPE } from '../../../common/enums';
 import { getDaysNum } from '../../../utils/calendarDays';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
+import { useDeepCompareEffect } from '../../../utils/useDeepCompareEffect';
 import EventButton from '../../eventButton/EventButton';
 
 const CalendarHeaderEvents = () => {
@@ -66,13 +67,13 @@ const CalendarHeaderEvents = () => {
   //   }, 600);
   // }, [store.headerEventRowsCount]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     const headerEventsRaw = renderEvents(
       store.headerLayout,
       store.layoutUpdateSequence + 1
     );
     setHeaderEvents(headerEventsRaw);
-  }, [JSON.stringify(store.headerLayout)]);
+  }, [store.headerLayout]);
 
   return (
     <div

--- a/src/components/daysViewTable/DaysViewTable.tsx
+++ b/src/components/daysViewTable/DaysViewTable.tsx
@@ -8,6 +8,7 @@ import {
   getSelectedViewType,
 } from '../../utils/common';
 import { useContext, useEffect, useLayoutEffect, useState } from 'react';
+import { useDeepCompareLayoutEffect } from '../../utils/useDeepCompareEffect';
 import CalendarBodyHours from './daysViewOneDay/calendarBodyHours/CalendarBodyHours';
 import DaysViewOneDay from './daysViewOneDay/DaysViewOneDay';
 import DaysViewVerticalLines from './daysViewVerticalLines/DaysViewVerticalLines';
@@ -126,7 +127,7 @@ const DaysViewTable = (props: DaysViewTableProps) => {
     }
   }, [width]);
 
-  useLayoutEffect(() => {
+  useDeepCompareLayoutEffect(() => {
     if (!hasExternalLayout) {
       KalendLayout({
         events,
@@ -151,7 +152,7 @@ const DaysViewTable = (props: DaysViewTableProps) => {
         setCalendarContent(days);
       });
     }
-  }, [JSON.stringify(events)]);
+  }, [events]);
 
   useLayoutEffect(() => {
     if (!hasExternalLayout) {
@@ -207,7 +208,7 @@ const DaysViewTable = (props: DaysViewTableProps) => {
     setWasInit(true);
   }, []);
 
-  useLayoutEffect(() => {
+  useDeepCompareLayoutEffect(() => {
     if (
       hasExternalLayout &&
       getSelectedViewType(props.eventLayouts.selectedView) ===
@@ -225,7 +226,7 @@ const DaysViewTable = (props: DaysViewTableProps) => {
       );
       setCalendarContent(days);
     }
-  }, [props.eventLayouts, JSON.stringify(props.eventLayouts)]);
+  }, [props.eventLayouts]);
 
   return (
     <div

--- a/src/components/monthView/MonthView.tsx
+++ b/src/components/monthView/MonthView.tsx
@@ -6,6 +6,7 @@ import { MonthViewProps } from './MonthView.props';
 import { getMonthRows } from './monthWeekRow/MonthWeekRow.utils';
 import { getSelectedViewType } from '../../utils/common';
 import { useContext, useEffect, useState } from 'react';
+import { useDeepCompareEffect } from '../../utils/useDeepCompareEffect';
 import DaysViewVerticalLines from '../daysViewTable/daysViewVerticalLines/DaysViewVerticalLines';
 import KalendLayout from 'kalend-layout';
 import MonthWeekRow from './monthWeekRow/MonthWeekRow';
@@ -79,7 +80,7 @@ const MonthView = (props: MonthViewProps) => {
     }
   }, [height, rawWidth]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (wasInit && height !== 0) {
       if (!hasExternalLayout) {
         KalendLayout({
@@ -103,9 +104,9 @@ const MonthView = (props: MonthViewProps) => {
         });
       }
     }
-  }, [calendarDays[0], JSON.stringify(events)]);
+  }, [calendarDays[0], events]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (
       hasExternalLayout &&
       getSelectedViewType(props.eventLayouts.selectedView) ===
@@ -123,7 +124,7 @@ const MonthView = (props: MonthViewProps) => {
       );
       setCalendarContent(content);
     }
-  }, [JSON.stringify(props.eventLayouts)]);
+  }, [props.eventLayouts]);
 
   return (
     <div className={'Kalend__MonthView__container'} style={style}>

--- a/src/layers/CalendarTableLayoutLayer.tsx
+++ b/src/layers/CalendarTableLayoutLayer.tsx
@@ -1,7 +1,8 @@
 import { Context, Store } from '../context/store';
 import { KalendState } from '../common/interface';
 import { getRange } from '../utils/calendarDays';
-import { useContext, useEffect, useLayoutEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { useDeepCompareLayoutEffect } from '../utils/useDeepCompareEffect';
 
 const CalendarTableLayoutLayer = (props: { children: any }) => {
   const [store] = useContext(Context);
@@ -20,7 +21,7 @@ const CalendarTableLayoutLayer = (props: { children: any }) => {
   }, [document.querySelector('.Kalend__Calendar__table')]);
 
   // Expose basic state to outside
-  useLayoutEffect(() => {
+  useDeepCompareLayoutEffect(() => {
     if (callbacks.onStateChange && isMounted) {
       const data: KalendState = {
         selectedView,
@@ -36,9 +37,9 @@ const CalendarTableLayoutLayer = (props: { children: any }) => {
     }
   }, [
     selectedView,
-    JSON.stringify(calendarDays),
+    calendarDays,
     width,
-    JSON.stringify(config),
+    config,
     store.isMobile,
     isMounted,
     direction,

--- a/src/layers/ConfigLayer.tsx
+++ b/src/layers/ConfigLayer.tsx
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon';
 import { KalendProps } from '../index';
 import { filterEventsByCalendarIDs } from '../utils/eventLayout';
 import { useContext, useEffect, useState } from 'react';
+import { useDeepCompareEffect } from '../utils/useDeepCompareEffect';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const emptyFunction = () => {};
@@ -161,17 +162,14 @@ const ConfigLayer = (props: KalendProps) => {
     setContext('config', newConfig);
   }, [props.hourHeight]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     const eventsFiltered: any = filterEventsByCalendarIDs(
       props.events,
       props.calendarIDsHidden
     );
 
     setContext('events', eventsFiltered);
-  }, [
-    JSON.stringify(props.calendarIDsHidden),
-    props.calendarIDsHidden?.length,
-  ]);
+  }, [props.calendarIDsHidden, props.calendarIDsHidden?.length]);
 
   return isReady ? props.children : null;
 };

--- a/src/utils/useDeepCompareEffect.ts
+++ b/src/utils/useDeepCompareEffect.ts
@@ -1,0 +1,28 @@
+import { dequal } from 'dequal';
+import { useEffect, useLayoutEffect, useRef } from 'react';
+
+export const useDeepCompareEffect: typeof useEffect = (
+  callback,
+  dependencies
+) => {
+  const ref = useRef<React.DependencyList>();
+  useEffect(() => {
+    if (!dequal(dependencies, ref.current)) {
+      ref.current = dependencies;
+      callback();
+    }
+  }, [callback, dependencies]);
+};
+
+export const useDeepCompareLayoutEffect: typeof useLayoutEffect = (
+  callback,
+  dependencies
+) => {
+  const ref = useRef<React.DependencyList>();
+  useLayoutEffect(() => {
+    if (!dequal(dependencies, ref.current)) {
+      ref.current = dependencies;
+      callback();
+    }
+  }, [callback, dependencies]);
+};


### PR DESCRIPTION
**Motivation:**
Using `JSON.stringify` in react hook dependency arrays is problematic in some cases. E.g. when passing events to `Kalend` component which are rendering custom event children. In such cases, the rendered react components can contain circulare structures, which `JSON.stringify` can not handle and will throw an error.

**Refactoring:**
Introduction of two custom hooks `useDeepCompareEffect` and `useDeepCompareLayoutEffect` following the [react community best practices](https://github.com/kentcdodds/use-deep-compare-effect) of applying deep object comparison to the hook dependency array. For deep object comparison, I added the [`dequal`](https://www.npmjs.com/package/dequal) package to the library dependency list, which covers a wide range of data types and has a tiny bundling foot print.