### PR TITLE
Missing optional tag for `timezoneStartAt` && `timezoneEndAt`

### DIFF
--- a/src/common/interface.ts
+++ b/src/common/interface.ts
@@ -17,8 +17,8 @@ export interface CalendarEvent {
   id: any;
   startAt: string;
   endAt: string;
-  timezoneStartAt: string;
-  timezoneEndAt: string;
+  timezoneStartAt?: string;
+  timezoneEndAt?: string;
   summary: string;
   color: string;
   internalID?: string; // for repeated event clones


### PR DESCRIPTION
This fixes the errors displayed in the image below
![image](https://user-images.githubusercontent.com/11464425/196005670-54b7b4dd-8944-4e4e-9e62-f350e59ac76c.png)