### PR TITLE
fix: avoid stale callbacks in config layer

### DIFF
--- a/src/layers/ConfigLayer.tsx
+++ b/src/layers/ConfigLayer.tsx
@@ -158,6 +158,14 @@ const ConfigLayer = (props: KalendProps) => {
     props.disableMobileDropdown,
     props.newEventText,
     props.weekDayStart,
+    // callbacks
+    props.onEventDragFinish,
+    props.onPageChange,
+    props.onSelectView,
+    props.onEventClick,
+    props.onNewEventClick,
+    props.showMoreMonth,
+    props.onStateChange,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
At the moment `createCallbacks()` is not called via `initFromProps()` if some callback passed to the `Kalend` component is changing. This causes kalend to call the stale callback from the initial render. 